### PR TITLE
Add condition to not call initialize for references in dsl

### DIFF
--- a/src/hex/compiletime/basic/CompileTimeContextFactory.hx
+++ b/src/hex/compiletime/basic/CompileTimeContextFactory.hx
@@ -299,7 +299,10 @@ class CompileTimeContextFactory
 	{
 		if ( MacroUtil.implementsInterface( MacroUtil.getClassType( constructorVO.className, null, false ), _moduleInterface ) )
 		{
-			this._moduleLocator.register( constructorVO.ID, constructorVO.ID );
+			if (constructorVO.ref == null)
+			{
+				this._moduleLocator.register( constructorVO.ID, constructorVO.ID );
+			}
 		}
 	}
 	


### PR DESCRIPTION
initialize() should not be called for references in dsl