### PR TITLE
Prevent to add autoInject for dsl references to object which…

### DIFF
--- a/src/hex/compiletime/basic/CompileTimeContextFactory.hx
+++ b/src/hex/compiletime/basic/CompileTimeContextFactory.hx
@@ -339,13 +339,16 @@ class CompileTimeContextFactory
 		{
 			if ( !constructorVO.injectInto )
 			{
-				this._injectedInto.push( 
-					macro 	@:pos( constructorVO.filePosition )
-							@:mergeBlock
-							{ 
-								__applicationContextInjector.injectInto( $i{ constructorVO.ID } ); 
-							}
-				);
+				if ( constructorVO.ref == null )
+				{
+					this._injectedInto.push( 
+						macro 	@:pos( constructorVO.filePosition )
+								@:mergeBlock
+								{ 
+									__applicationContextInjector.injectInto( $i{ constructorVO.ID } ); 
+								}
+					);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Add condition which prevent to add injectInto for references to object which have autoInject (like ICommandTrigger)

For example if class A implements ICommandTrigger
and in dsl flow we have

**@context
{
	value = new A();
	value1 = value;
}**

in output code we will receive

**this.value = value;
var value1 = value;
__applicationContextInjector.injectInto(value); 
__applicationContextInjector.injectInto(value1);** 

what's imho should not